### PR TITLE
Add setLzEndpoint to OZNFTBaseUpgradeable

### DIFF
--- a/src/OZNFTBaseUpgradeable.sol
+++ b/src/OZNFTBaseUpgradeable.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.13;
 
 import {ONFT721Upgradeable} from "./layerZero/ONFT721Upgradeable.sol";
-import {ILayerZeroEndpointUpgradeable} from "./layerZero/lzAppUpgradeable.sol";
+import {ILayerZeroEndpointUpgradeable} from "./layerZero/LzAppUpgradeable.sol";
 import {ERC721Upgradeable, IERC721Upgradeable} from "openzeppelin-upgradeable/token/ERC721/ERC721Upgradeable.sol";
 
 import {NFTBaseUpgradeable} from "./NFTBaseUpgradeable.sol";

--- a/src/OZNFTBaseUpgradeable.sol
+++ b/src/OZNFTBaseUpgradeable.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.13;
 
 import {ONFT721Upgradeable} from "./layerZero/ONFT721Upgradeable.sol";
+import {ILayerZeroEndpointUpgradeable} from "./layerZero/lzAppUpgradeable.sol";
 import {ERC721Upgradeable, IERC721Upgradeable} from "openzeppelin-upgradeable/token/ERC721/ERC721Upgradeable.sol";
 
 import {NFTBaseUpgradeable} from "./NFTBaseUpgradeable.sol";
@@ -52,6 +53,19 @@ abstract contract OZNFTBaseUpgradeable is NFTBaseUpgradeable, ONFT721Upgradeable
     function setUnrevealedURI(string calldata _unrevealedURI) external override onlyOwner {
         unrevealedURI = _unrevealedURI;
         emit UnrevealedURISet(unrevealedURI);
+    }
+
+    /**
+     * @notice Set LayerZeroEndpoint address
+     * @param _endpoint address of LayerZeroEndpoint to set
+     */
+    function setLzEndpoint(address _endpoint) external override onlyOwner {
+        if (_endpoint == address(0)) {
+            revert OZNFTBaseUpgradeable__InvalidAddress();
+        }
+
+        lzEndpoint = ILayerZeroEndpointUpgradeable(_endpoint);
+        emit LZEndpointSet(_endpoint);
     }
 
     /**

--- a/src/interfaces/IOZNFTBaseUpgradeable.sol
+++ b/src/interfaces/IOZNFTBaseUpgradeable.sol
@@ -9,8 +9,11 @@ import {
 import {INFTBaseUpgradeable} from "./INFTBaseUpgradeable.sol";
 
 interface IOZNFTBaseUpgradeable is INFTBaseUpgradeable, IONFT721Upgradeable {
+    error OZNFTBaseUpgradeable__InvalidAddress();
+
     event BaseURISet(string baseURI);
     event UnrevealedURISet(string unrevealedURI);
+    event LZEndpointSet(address lzEndpoint);
 
     function unrevealedURI() external view returns (string memory);
 
@@ -19,6 +22,8 @@ interface IOZNFTBaseUpgradeable is INFTBaseUpgradeable, IONFT721Upgradeable {
     function setBaseURI(string calldata baseURI) external;
 
     function setUnrevealedURI(string calldata baseURI) external;
+
+    function setLzEndpoint(address lzEndpoint) external;
 
     function supportsInterface(bytes4 interfaceId)
         external

--- a/test/NFTBaseUpgradeable.t.sol
+++ b/test/NFTBaseUpgradeable.t.sol
@@ -140,8 +140,8 @@ contract NFTBaseUpgradeableTest is TestHelper {
         nftBase.setRoyaltyInfo(royaltyReceiver, royaltiesPercent);
     }
 
-    function test_WithdrawAVAX(uint256 amount, address alice) public {
-        vm.assume(alice.code.length == 0);
+    function test_WithdrawAVAX(uint256 amount) public {
+        address alice = makeAddr("alice");
         amount = bound(amount, 0.01 ether, 100_000 ether);
         deal(address(nftBase), amount);
 
@@ -156,9 +156,9 @@ contract NFTBaseUpgradeableTest is TestHelper {
         assertEq(alice.balance, amount - fee, "test_WithdrawAVAX::2");
     }
 
-    function test_WithdrawAVAXWhenProjectOwner(address alice, address bob, uint256 amount) public {
-        vm.assume(alice.code.length == 0);
-        vm.assume(bob != address(this) && bob != joepegs && bob.code.length == 0);
+    function test_WithdrawAVAXWhenProjectOwner(uint256 amount) public {
+        address alice = makeAddr("alice");
+        address bob = makeAddr("bob");
 
         amount = bound(amount, 0.01 ether, 100_000 ether);
         deal(address(nftBase), amount);

--- a/test/OZNFTBaseUpgradeable.t.sol
+++ b/test/OZNFTBaseUpgradeable.t.sol
@@ -79,6 +79,26 @@ contract OZNFTBaseUpgradeableTest is TestHelper {
         ozNftBase.setUnrevealedURI(unrevealedURI);
     }
 
+    function test_SetLzEndpointAddress(address lzEndpoint) public {
+        vm.assume(lzEndpoint != address(0));
+        ozNftBase.setLzEndpoint(lzEndpoint);
+
+        assertEq(address(ozNftBase.lzEndpoint()), lzEndpoint, "test_SetLzEndpointAddress::1");
+    }
+
+    function test_Revert_SetLzEndpointAddressWhenNotOwner(address alice, address lzEndpoint) public {
+        vm.assume(alice != address(0) && alice != address(this));
+
+        vm.expectRevert(IPendingOwnableUpgradeable.PendingOwnableUpgradeable__NotOwner.selector);
+        vm.prank(alice);
+        ozNftBase.setLzEndpoint(lzEndpoint);
+    }
+
+    function test_Revert_SetLzEndpointAddressToZero() public {
+        vm.expectRevert(IOZNFTBaseUpgradeable.OZNFTBaseUpgradeable__InvalidAddress.selector);
+        ozNftBase.setLzEndpoint(address(0));
+    }
+
     function test_SupportInterface() public {
         assertTrue(
             ozNftBase.supportsInterface(type(IERC165Upgradeable).interfaceId)


### PR DESCRIPTION
I realized there is no setter function to update the LZ endpoint address if needed.